### PR TITLE
make overview not inherit the index layout

### DIFF
--- a/_layouts/overview.html
+++ b/_layouts/overview.html
@@ -1,0 +1,16 @@
+---
+layout: default
+---
+<div class="row justify-content-center">
+  <div class="col-11 col-lg-8 card shadow gx-5 gy-5 m-lg-5">
+    <div class="row g-0">
+      <div class="col-auto">
+        <div class="card-body">
+          <div class="card-text m-2">
+            {{ content | markdownify }}
+          </div>
+        </div>
+      </div>
+    </div>
+  </div>
+</div>

--- a/overview.markdown
+++ b/overview.markdown
@@ -1,5 +1,5 @@
 ---
-layout: index
+layout: overview
 title: Overview
 permalink: /overview/
 ---


### PR DESCRIPTION
The overview was picking up the hero, which I don't think was our intent.